### PR TITLE
Single Item can be automatically selected

### DIFF
--- a/idp-authn-api-discovery/pom.xml
+++ b/idp-authn-api-discovery/pom.xml
@@ -25,7 +25,7 @@ THE SOFTWARE.
   <parent>
     <artifactId>idp-authn-discovery</artifactId>
     <groupId>fi.csc.shibboleth</groupId>
-    <version>2.2.0-alpha</version>
+    <version>2.2.0</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>idp-authn-api-discovery</artifactId>

--- a/idp-authn-api-discovery/pom.xml
+++ b/idp-authn-api-discovery/pom.xml
@@ -25,7 +25,7 @@ THE SOFTWARE.
   <parent>
     <artifactId>idp-authn-discovery</artifactId>
     <groupId>fi.csc.shibboleth</groupId>
-    <version>2.1.0</version>
+    <version>2.2.0-alpha</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>idp-authn-api-discovery</artifactId>

--- a/idp-authn-impl-discovery/pom.xml
+++ b/idp-authn-impl-discovery/pom.xml
@@ -25,7 +25,7 @@ THE SOFTWARE.
   <parent>
     <artifactId>idp-authn-discovery</artifactId>
     <groupId>fi.csc.shibboleth</groupId>
-    <version>2.2.0-alpha</version>
+    <version>2.2.0</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>idp-authn-impl-discovery</artifactId>

--- a/idp-authn-impl-discovery/pom.xml
+++ b/idp-authn-impl-discovery/pom.xml
@@ -25,7 +25,7 @@ THE SOFTWARE.
   <parent>
     <artifactId>idp-authn-discovery</artifactId>
     <groupId>fi.csc.shibboleth</groupId>
-    <version>2.1.0</version>
+    <version>2.2.0-alpha</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>idp-authn-impl-discovery</artifactId>

--- a/idp-authn-impl-discovery/src/main/resources/META-INF/net/shibboleth/idp/flows/authn/Disco/disco-beans.xml
+++ b/idp-authn-impl-discovery/src/main/resources/META-INF/net/shibboleth/idp/flows/authn/Disco/disco-beans.xml
@@ -56,7 +56,8 @@ THE SOFTWARE.
             p:httpServletRequestSupplier-ref="shibboleth.HttpServletRequestSupplier"
             p:authorityProperties="%{idp.discovery.authority.properties:}"
             p:authorities="%{idp.discovery.authorities:}"
-            p:autoSelectSingleItem="%{idp.discovery.autoSelectSingleItem:false}" />
+            p:autoSelectSingleItem="%{idp.discovery.autoSelectSingleItem:false}"
+            p:ignoredFlows="%{idp.discovery.ignoredFlows:authn/Disco}" />
 
     <bean id="shibboleth.authn.Discovery.AuthnFlowFieldName" class="java.lang.String" c:_0="j_authnflow" />
     <bean id="shibboleth.authn.Discovery.SelectedAuthorityFieldName" class="java.lang.String" c:_0="j_authnauthority" />

--- a/idp-authn-impl-discovery/src/main/resources/META-INF/net/shibboleth/idp/flows/authn/Disco/disco-beans.xml
+++ b/idp-authn-impl-discovery/src/main/resources/META-INF/net/shibboleth/idp/flows/authn/Disco/disco-beans.xml
@@ -55,7 +55,8 @@ THE SOFTWARE.
             class="fi.csc.shibboleth.authn.impl.PopulateDiscoveryContext"
             p:httpServletRequestSupplier-ref="shibboleth.HttpServletRequestSupplier"
             p:authorityProperties="%{idp.discovery.authority.properties:}"
-            p:authorities="%{idp.discovery.authorities:}" />
+            p:authorities="%{idp.discovery.authorities:}"
+            p:storeSelection="%{idp.discovery.autoSelectSingleItem:false}" />
 
     <bean id="shibboleth.authn.Discovery.AuthnFlowFieldName" class="java.lang.String" c:_0="j_authnflow" />
     <bean id="shibboleth.authn.Discovery.SelectedAuthorityFieldName" class="java.lang.String" c:_0="j_authnauthority" />

--- a/idp-authn-impl-discovery/src/main/resources/META-INF/net/shibboleth/idp/flows/authn/Disco/disco-beans.xml
+++ b/idp-authn-impl-discovery/src/main/resources/META-INF/net/shibboleth/idp/flows/authn/Disco/disco-beans.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
             p:httpServletRequestSupplier-ref="shibboleth.HttpServletRequestSupplier"
             p:authorityProperties="%{idp.discovery.authority.properties:}"
             p:authorities="%{idp.discovery.authorities:}"
-            p:storeSelection="%{idp.discovery.autoSelectSingleItem:false}" />
+            p:autoSelectSingleItem="%{idp.discovery.autoSelectSingleItem:false}" />
 
     <bean id="shibboleth.authn.Discovery.AuthnFlowFieldName" class="java.lang.String" c:_0="j_authnflow" />
     <bean id="shibboleth.authn.Discovery.SelectedAuthorityFieldName" class="java.lang.String" c:_0="j_authnauthority" />

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ THE SOFTWARE.
   <modelVersion>4.0.0</modelVersion>
   <groupId>fi.csc.shibboleth</groupId>
   <artifactId>idp-authn-discovery</artifactId>
-  <version>2.1.0</version>
+  <version>2.2.0-alpha</version>
   <packaging>pom</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ THE SOFTWARE.
   <modelVersion>4.0.0</modelVersion>
   <groupId>fi.csc.shibboleth</groupId>
   <artifactId>idp-authn-discovery</artifactId>
-  <version>2.2.0-alpha</version>
+  <version>2.2.0</version>
   <packaging>pom</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Single items can be automatically selected by setting `idp.discovery.autoSelectSingleItem=true`
Flows can be ignored by listing them with comma separated list` idp.discovery.ignoredFlows=authn/Disco`.